### PR TITLE
Add types/tokenizers.d.ts for Angular/Vite/Rollup compatibility

### DIFF
--- a/src/static/tokenizer.ts
+++ b/src/static/tokenizer.ts
@@ -279,7 +279,7 @@ export type TokenizerConfigPreTokenizer =
 // PostProcessor
 // ----------------------------------------------------------------------------
 
-interface SpecialToken {
+export interface SpecialToken {
   id: string;
   ids: number[];
   tokens: string[];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "types": ["node", "jest"],
     "baseUrl": ".",
     "paths": {
-      "@utils": ["src/utils/index.ts"],
+      "@utils": ["src/utils/index"],
       "@utils/*": ["src/utils/*"],
       "@core/*": ["src/core/*"],
       "@static/*": ["src/static/*"]


### PR DESCRIPTION
Closes #31 

TypeScript doesn't rewrite path aliases in .d.ts output. `tsc-alias` handles this as a post-processing step, but it doesn't work under "moduleResolution": "bundler" (Angular 17+). Also, `/types/static/tokenizers.d.ts` is not being generated.

~~* Replaces internal path aliases (`@utils`, `@core/*`, `@static/*`) with relative imports so the emitted declarations are correct without any post-processing.  This makes `tsc-alias` longer needed and is removed.~~
* Renames `src/static/tokenizer.d.ts` to `src/static/tokenizer.ts` to ensure `tsc` emits  `types/static/tokenizer.d.ts`
* Updates `tsconfig.json` from `src/utils/index.ts` to `src/utils/index` to ensure `tsc-alias` rewrites `@utils` correctly.
* Adds a "bundler" exports condition to `package.json`

Without these changes, Angular 17+ (and other bundlers that resolve the "bundler" exports condition) fail to build with errors like:

```
TS2305: Module '"@static/tokenizer"' has no exported member 'TokenizerConfigDecoder'
TS2693: 'Callable' only refers to a type, but is being used as a value here
TS2305: Module '"@static/tokenizer"' has no exported member 'TokenizerConfigNormalizerBert'.
TS2305: Module '"@static/tokenizer"' has no exported member 'TokenizerConfigNormalizerLowercase'.
TS2305: Module '"@static/tokenizer"' has no exported member 'TokenizerConfigNormalizerPrecompiled'.
etc.
```